### PR TITLE
Clear answer when deselecting choices in table-list plugin

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name" : "Table list",
 	"author" : "Dobility",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"supportedFieldTypes": ["select_one","select_multiple"],
 	"externalCss" :["bootstrap.min.css","dataTables.bootstrap4.min.css","fixedHeader.bootstrap4.min.css","select.bootstrap4.min.css"],
 	"externalJs" : ["jquery-3.5.0.min.js","popper.min.js","bootstrap.min.js","jquery.dataTables.min.js","dataTables.bootstrap4.min.js","dataTables.fixedHeader.min.js","dataTables.select.min.js"],

--- a/source/script.js
+++ b/source/script.js
@@ -140,10 +140,12 @@ function setValue (value) {
   if (fieldType === 'select_multiple' && value.length > 1) { // check if to expect more than one selection
     const answer = value.join(' ') // Change array into space seperated string
     setAnswer(answer) // Set this as the answer for this field
-  } else {
+  } else if (fieldType === 'select_one') {
     if (value.length === 1) { // Check if only one answer is checked
-      const answer = value.toString(value) // Change a array into a string value
-      setAnswer(answer) // Set this as the answer for the field
+      const answer = value.toString(); // Change an array into a string value
+      setAnswer(answer); // Set this as the answer for the field
+    } else if (value.length === 0) { // No selection made
+      setAnswer(''); // Clear the answer for this field
     }
   }
 }


### PR DESCRIPTION
This pull request fixes an issue in the table-list plugin's single-choice (select_one) field. Initially, deselecting an option did not clear the selection. With this update, deselecting an option now sets the answer to an empty string, eliminating any unintended choices.